### PR TITLE
Use new Hash format for HSR EnkaDB JSON files.

### DIFF
--- a/Sources/EnkaDBGeneratorModule/DimbreathModels/DimDBImpls_Assembler/DimDB4HSR_Assembler.swift
+++ b/Sources/EnkaDBGeneratorModule/DimbreathModels/DimDBImpls_Assembler/DimDB4HSR_Assembler.swift
@@ -46,8 +46,8 @@ extension DimModels4HSR.DimDB4HSR {
             }
             // Assembling the results.
             let assembled = EnkaDBModelsHSR.Character(
-                avatarName: .init(hash: currentAvatar.avatarName.hash),
-                avatarFullName: .init(hash: currentAvatar.avatarFullName.hash),
+                avatarName: .init(hash: currentAvatar.avatarName.hash.description),
+                avatarFullName: .init(hash: currentAvatar.avatarFullName.hash.description),
                 rarity: rarityLevel,
                 element: currentAvatar.damageType,
                 avatarBaseType: currentAvatar.avatarBaseType, // Lifepath.
@@ -82,7 +82,7 @@ extension DimModels4HSR.DimDB4HSR {
             let assembled = EnkaDBModelsHSR.Weapon(
                 rarity: rarityLevel,
                 avatarBaseType: currentWeapon.avatarBaseType,
-                equipmentName: .init(hash: currentWeapon.equipmentName.hash),
+                equipmentName: .init(hash: currentWeapon.equipmentName.hash.description),
                 imagePath: currentWeapon.imagePath.replacingOccurrences(
                     of: "LightConeMaxFigures",
                     with: "LightConeFigures"

--- a/Sources/EnkaDBModels/EnkaDBModelsHSR.swift
+++ b/Sources/EnkaDBModels/EnkaDBModelsHSR.swift
@@ -88,8 +88,18 @@ extension EnkaDBModelsHSR {
         public struct AvatarFullName: Codable, Hashable {
             // MARK: Lifecycle
 
-            public init(hash: UInt) {
+            public init(hash: String) {
                 self.hash = hash
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let decodedStr = try? container.decode(String.self, forKey: .hash)
+                if let decodedStr {
+                    self.hash = decodedStr
+                    return
+                }
+                self.hash = try container.decode(UInt64.self, forKey: .hash).description
             }
 
             // MARK: Public
@@ -98,14 +108,29 @@ extension EnkaDBModelsHSR {
                 case hash = "Hash"
             }
 
-            public var hash: UInt
+            public var hash: String
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(hash, forKey: .hash)
+            }
         }
 
         public struct AvatarName: Codable, Hashable {
             // MARK: Lifecycle
 
-            public init(hash: UInt) {
+            public init(hash: String) {
                 self.hash = hash
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let decodedStr = try? container.decode(String.self, forKey: .hash)
+                if let decodedStr {
+                    self.hash = decodedStr
+                    return
+                }
+                self.hash = try container.decode(UInt64.self, forKey: .hash).description
             }
 
             // MARK: Public
@@ -114,7 +139,12 @@ extension EnkaDBModelsHSR {
                 case hash = "Hash"
             }
 
-            public var hash: UInt
+            public var hash: String
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(hash, forKey: .hash)
+            }
         }
 
         public enum CodingKeys: String, CodingKey {
@@ -530,8 +560,18 @@ extension EnkaDBModelsHSR {
         public struct EquipmentName: Codable, Hashable {
             // MARK: Lifecycle
 
-            public init(hash: UInt) {
+            public init(hash: String) {
                 self.hash = hash
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let decodedStr = try? container.decode(String.self, forKey: .hash)
+                if let decodedStr {
+                    self.hash = decodedStr
+                    return
+                }
+                self.hash = try container.decode(UInt64.self, forKey: .hash).description
             }
 
             // MARK: Public
@@ -540,7 +580,12 @@ extension EnkaDBModelsHSR {
                 case hash = "Hash"
             }
 
-            public var hash: UInt
+            public var hash: String
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(hash, forKey: .hash)
+            }
         }
 
         public enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
- Star Rail since v3.1 utilizes UInt64 (Int128 but >= 0) for NameTextMapHash values. Enka officially ended up using String instead for maximum compatibility.